### PR TITLE
Added missing type arguments when using Tuple2 constructor

### DIFF
--- a/src/main/java/org/krayne/kantan/tuple/Tuple2.java
+++ b/src/main/java/org/krayne/kantan/tuple/Tuple2.java
@@ -5,7 +5,7 @@ public class Tuple2<A, B> {
     private final B v2;
 
     public static <A, B> Tuple2<A, B> of(A v1, B v2) {
-        return new Tuple2(v1, v2);
+        return new Tuple2<A, B>(v1, v2);
     }
 
     private Tuple2(A v1, B v2) {


### PR DESCRIPTION
Added generic type arguments when using the Tuple2 constructor.

Below were the warnings I saw pop up when adding -Xlint:all to pom.xml to show compiler warnings.

```
[WARNING] /Users/phungs/workspace/code/test/kantan/src/main/java/org/krayne/kantan/tuple/Tuple2.java:[8,20] found raw type: org.krayne.kantan.tuple.Tuple2
  missing type arguments for generic class org.krayne.kantan.tuple.Tuple2<A,B>
[WARNING] /Users/phungs/workspace/code/test/kantan/src/main/java/org/krayne/kantan/tuple/Tuple2.java:[8,16] unchecked call to Tuple2(A,B) as a member of the raw type org.krayne.kantan.tuple.Tuple2
[WARNING] /Users/phungs/workspace/code/test/kantan/src/main/java/org/krayne/kantan/tuple/Tuple2.java:[8,16] unchecked conversion
  required: org.krayne.kantan.tuple.Tuple2<A,B>
  found:    org.krayne.kantan.tuple.Tuple2
```
